### PR TITLE
fixed ResourceUtils by reading resource content as inputStream

### DIFF
--- a/src/main/java/gov/cms/mat/cql_elm_translation/exceptions/ControllerExceptionHandler.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/exceptions/ControllerExceptionHandler.java
@@ -1,0 +1,44 @@
+package gov.cms.mat.cql_elm_translation.exceptions;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.Map;
+
+@ControllerAdvice
+@RequiredArgsConstructor
+public class ControllerExceptionHandler {
+
+  private final ErrorAttributes errorAttributes;
+
+  @ExceptionHandler(ResourceNotFoundException.class)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  @ResponseBody
+  Map<String, Object> onResourceNotFoundException(WebRequest request) {
+    return getErrorAttributes(request, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(InternalServerException.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  @ResponseBody
+  Map<String, Object> onInternalServerException(WebRequest request) {
+    return getErrorAttributes(request, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  private Map<String, Object> getErrorAttributes(WebRequest request, HttpStatus httpStatus) {
+    ErrorAttributeOptions errorOptions =
+        ErrorAttributeOptions.of(ErrorAttributeOptions.Include.MESSAGE);
+    Map<String, Object> errorAttributes =
+        this.errorAttributes.getErrorAttributes(request, errorOptions);
+    errorAttributes.put("status", httpStatus.value());
+    errorAttributes.put("error", httpStatus.getReasonPhrase());
+    return errorAttributes;
+  }
+}

--- a/src/main/java/gov/cms/mat/cql_elm_translation/exceptions/InternalServerException.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/exceptions/InternalServerException.java
@@ -1,0 +1,8 @@
+package gov.cms.mat.cql_elm_translation.exceptions;
+
+public class InternalServerException extends RuntimeException {
+
+  public InternalServerException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/gov/cms/mat/cql_elm_translation/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/exceptions/ResourceNotFoundException.java
@@ -1,9 +1,5 @@
 package gov.cms.mat.cql_elm_translation.exceptions;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(value = HttpStatus.BAD_REQUEST)
 public class ResourceNotFoundException extends RuntimeException {
   private static final String MESSAGE = "Could not find %s resource for measure: %s";
 

--- a/src/main/java/gov/cms/mat/cql_elm_translation/utils/ResourceUtils.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/utils/ResourceUtils.java
@@ -1,17 +1,21 @@
 package gov.cms.mat.cql_elm_translation.utils;
 
-import java.io.File;
+import gov.cms.mat.cql_elm_translation.exceptions.InternalServerException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
 
 public class ResourceUtils {
   public static String getData(String resource) {
-    File file = new File(ResourceUtils.class.getResource(resource).getFile());
-    try {
-      return new String(Files.readAllBytes(file.toPath()));
+    try (InputStream inputStream = ResourceUtils.class.getResourceAsStream(resource)) {
+      if (inputStream == null) {
+        throw new InternalServerException("Unable to fetch resource " + resource);
+      }
+      return new String(inputStream.readAllBytes());
     } catch (IOException e) {
       throw new UncheckedIOException(e);
+    } catch (NullPointerException nullPointerException) {
+      throw new InternalServerException("Resource name cannot be null");
     }
   }
 }


### PR DESCRIPTION
## CQL to ELM Translation Service PR

Jira Ticket: [MAT-5264](https://jira.cms.gov/browse/MAT-5264)
(Optional) Related Tickets:

### Summary

- Turns out measure.liquid template file was unavailable from classpath. It could be a permission issue.
- So updated the implementation of the resource loading, using inputStream rather than reading it as a File.
- Also improved the exception handling by using Controller Advice.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
