### PR TITLE
MAT-6107 get unqualified id after setting full urls to resources in bundle

### DIFF
--- a/src/main/java/gov/cms/mat/cql_elm_translation/service/EffectiveDataRequirementService.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/service/EffectiveDataRequirementService.java
@@ -147,8 +147,7 @@ public class EffectiveDataRequirementService {
             entry ->
                 StringUtils.equalsIgnoreCase(
                         "Library", entry.getResource().getResourceType().toString())
-                    && StringUtils.equalsIgnoreCase(
-                        "Library/" + libraryName, entry.getResource().getId()))
+                    && StringUtils.equalsIgnoreCase(libraryName, entry.getResource().getIdPart()))
         .findFirst();
   }
 


### PR DESCRIPTION

## CQL to ELM Translation Service PR

Jira Ticket: [MAT-6107](https://jira.cms.gov/browse/MAT-6107)
(Optional) Related Tickets:

### Summary
When resource has full url, getId() will returns qualified id. e.g for Library with id 123, it provides `Library/123`. To get just id, we need to use `getIdPart` method  
 
### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
