### PR TITLE
[MAT-6742] Set Response Content Type to resolve XSS vuln

### DIFF
--- a/src/main/java/gov/cms/mat/cql_elm_translation/controllers/CqlToolsController.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/controllers/CqlToolsController.java
@@ -32,7 +32,7 @@ public class CqlToolsController {
   private final HumanReadableService humanReadableService;
   private final CqlParsingService cqlParsingService;
 
-  @PutMapping("/cql/format")
+  @PutMapping(value = "/cql/format", produces = {MediaType.TEXT_PLAIN_VALUE})
   public ResponseEntity<String> formatCql(@RequestBody String cqlData, Principal principal) {
     try (var cqlDataStream = new ByteArrayInputStream(cqlData.getBytes())) {
       CqlFormatterVisitor.FormatResult formatResult =
@@ -43,7 +43,9 @@ public class CqlToolsController {
             "Unable to format CQL, because one or more Syntax errors are identified");
       }
       log.info("User [{}] successfully formatted the CQL", principal.getName());
-      return ResponseEntity.ok(formatResult.getOutput());
+      return ResponseEntity.ok()
+          .contentType(MediaType.TEXT_PLAIN)
+          .body(formatResult.getOutput());
     } catch (IOException e) {
       log.info("User [{}] is unable to format the CQL", principal.getName());
       throw new CqlFormatException(e.getMessage());


### PR DESCRIPTION
## CQL to ELM Translation Service PR

Jira Ticket: [MAT-6742](https://jira.cms.gov/browse/MAT-6742)
(Optional) Related Tickets:

### Summary
Unsanitized input from the HTTP request body flows into here, where it is used to render an HTML page returned to the user. This may result in a Cross-Site Scripting attack (XSS).

Set Content-Type header on response to mitigate possible XSS attacks.


### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
