### PR TITLE
MAT-9834: Catch Cache.ValueRetrievalException in getLibraryCql and re…

### DIFF
--- a/src/main/java/gov/cms/mat/cql_elm_translation/config/security/UserServiceClientConfig.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/config/security/UserServiceClientConfig.java
@@ -16,8 +16,6 @@ public class UserServiceClientConfig {
         new MappingJackson2HttpMessageConverter();
     messageConverter.setObjectMapper(objectMapper);
 
-    return new RestTemplateBuilder()
-        .additionalMessageConverters(messageConverter)
-        .build();
+    return new RestTemplateBuilder().additionalMessageConverters(messageConverter).build();
   }
 }

--- a/src/main/java/gov/cms/mat/cql_elm_translation/service/CachedCqlLibraryService.java
+++ b/src/main/java/gov/cms/mat/cql_elm_translation/service/CachedCqlLibraryService.java
@@ -1,6 +1,7 @@
 package gov.cms.mat.cql_elm_translation.service;
 
 import gov.cms.madie.cql_elm_translator.service.CqlLibraryService;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -25,8 +26,12 @@ public class CachedCqlLibraryService extends CqlLibraryService {
 
   @Override
   public String getLibraryCql(String name, String version, String accessToken) {
-    return cacheManager
-        .getCache("cqlLibraries")
-        .get(name + "_" + version, () -> super.getLibraryCql(name, version, accessToken));
+    try {
+      return cacheManager
+          .getCache("cqlLibraries")
+          .get(name + "_" + version, () -> super.getLibraryCql(name, version, accessToken));
+    } catch (Cache.ValueRetrievalException e) {
+      throw (RuntimeException) e.getCause();
+    }
   }
 }

--- a/src/test/java/gov/cms/mat/cql_elm_translation/service/CachedCqlLibraryServiceTest.java
+++ b/src/test/java/gov/cms/mat/cql_elm_translation/service/CachedCqlLibraryServiceTest.java
@@ -2,7 +2,6 @@ package gov.cms.mat.cql_elm_translation.service;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import gov.cms.madie.cql_elm_translator.exceptions.LibraryResourceLoaderException;
-import org.springframework.cache.Cache;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,7 +18,6 @@ import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -81,18 +79,27 @@ class CachedCqlLibraryServiceTest {
         .when(restTemplate)
         .exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class));
 
-    Cache.ValueRetrievalException ex1 =
-        assertThrows(
-            Cache.ValueRetrievalException.class,
-            () -> cachedCqlLibraryService.getLibraryCql(NAME, VERSION, ACCESS_TOKEN));
-    assertInstanceOf(LibraryResourceLoaderException.class, ex1.getCause());
+    assertThrows(
+        LibraryResourceLoaderException.class,
+        () -> cachedCqlLibraryService.getLibraryCql(NAME, VERSION, ACCESS_TOKEN));
 
-    Cache.ValueRetrievalException ex2 =
-        assertThrows(
-            Cache.ValueRetrievalException.class,
-            () -> cachedCqlLibraryService.getLibraryCql(NAME, VERSION, ACCESS_TOKEN));
-    assertInstanceOf(LibraryResourceLoaderException.class, ex2.getCause());
+    assertThrows(
+        LibraryResourceLoaderException.class,
+        () -> cachedCqlLibraryService.getLibraryCql(NAME, VERSION, ACCESS_TOKEN));
 
     verify(restTemplate, times(2)).exchange(any(URI.class), any(), any(), eq(String.class));
+  }
+
+  @Test
+  void getLibraryCqlThrowsWhenVersionIsNull() {
+    HttpClientErrorException notFound = mock(HttpClientErrorException.NotFound.class);
+    doThrow(notFound)
+        .when(restTemplate)
+        .exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class));
+
+    assertThrows(
+        LibraryResourceLoaderException.class,
+        () -> cachedCqlLibraryService.getLibraryCql(NAME, null, ACCESS_TOKEN));
+    verify(restTemplate, times(1)).exchange(any(URI.class), any(), any(), eq(String.class));
   }
 }


### PR DESCRIPTION
…throw the cause directly, restoring pre-caching exception behavior for all error cases

## CQL to ELM Translation Service PR

Jira Ticket: [MAT-9834](https://jira.cms.gov/browse/MAT-9834)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
